### PR TITLE
removed exercise ids and converted example ids

### DIFF
--- a/ptx/dihedralgps.ptx
+++ b/ptx/dihedralgps.ptx
@@ -5,9 +5,9 @@
     Dihedral groups are groups of symmetries of regular <m>n</m>-gons. We start with an example.
   </p>
 
-  <example>
+  <example xml:id="D3">
     <p>
-      {D3} Consider a regular triangle <m>T</m>, with vertices labeled <m>1</m>, <m>2</m>, and <m>3</m>. We show <m>T</m> below, also using dotted lines to indicate a vertical line of symmetry of <m>T</m> and a rotation of <m>T</m>.
+      Consider a regular triangle <m>T</m>, with vertices labeled <m>1</m>, <m>2</m>, and <m>3</m>. We show <m>T</m> below, also using dotted lines to indicate a vertical line of symmetry of <m>T</m> and a rotation of <m>T</m>.
     </p>
     <image source="images/b50c1bb2439484680b8b510a03e8baafdb6dce06.png"/>
     <p>

--- a/ptx/index.ptx
+++ b/ptx/index.ptx
@@ -3,9 +3,9 @@
 <docinfo>
 <macros>
 \renewcommand{\bibname}{References and Supplemental Resources}
-\newcommand{\defhead}{}
+\renewcommand{\arraystretch}{1.3}
 \def\Z{\mathbb{Z}}
-\renewcommand{\defhead}{#1}
+\renewcommand{\arraystretch}{1.3}
 \def\zn{\mathbb{Z}_n}
 \renewcommand{\arraystretch}{1.3}
 \def\znc{\mathbb{Z}_n^\times}
@@ -31,19 +31,17 @@
 \def\0{\mathbf 0}
 \renewcommand{\arraystretch}{1.3}
 \def\Gdot{\langle G, \cdot\,\rangle}
-\renewcommand{\arraystretch}{1.3}
+\renewcommand{\arraystretch}{2}
 \def\phibar{\overline{\phi}}
 \renewcommand{\arraystretch}{1.3}
 \DeclareMathOperator{\lcm}{lcm}
-\renewcommand{\arraystretch}{2}
+\renewcommand{\arraystretch}{1.3}
 \DeclareMathOperator{\Ker}{Ker}
 \renewcommand{\arraystretch}{1.3}
 \def\siml{\sim_L}
-\renewcommand{\arraystretch}{1.3}
-\def\simr{\sim_R}
-\renewcommand{\arraystretch}{1.3}
-\def\cont{\subseteq}
 \renewcommand{\headrulewidth}{0pt}
+\def\simr{\sim_R}
+\def\cont{\subseteq}
 \def\epsilon{\varepsilon}
 \def\lra{\Leftrightarrow}
 \def\tf{True/False. For each of the following, write T if the statement is

--- a/ptx/section1-5.ptx
+++ b/ptx/section1-5.ptx
@@ -2,7 +2,6 @@
 <section>
   <title>Exercises</title>
   <exercise>
-    <title>ID=1A</title>
     <statement>
       <p>
         Yes/No. For each of the following, write Y if the object described is a well-defined set; otherwise, write N. You do NOT need to provide explanations or show work for this problem.
@@ -63,7 +62,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=1B</title>
     <statement>
       <p>
         List the elements in the following sets, writing your answers as sets.
@@ -129,7 +127,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=1C</title>
     <statement>
       <p>
         Let <m>S</m> be a set with cardinality <m>n\in \fatn</m>. Use the cardinalities of <m>P(\{a,b\})</m> and <m>P(\{a,b,c\})</m> to make a conjecture about the cardinality of <m>P(S)</m>. You do not need to prove that your conjecture is correct (but you should try to ensure it is correct).
@@ -143,7 +140,6 @@
     </p>
   </solution>
   <exercise>
-    <title>ID=1D</title>
     <statement>
       <p>
         Let <m>f: \Z^2 \to \fatr</m> be defined by <m>f(a,b)=ab</m>. (Note: technically, we should write <m>f((a,b))</m>, not <m>f(a,b)</m>, since <m>f</m> is being applied to an ordered pair, but this is one of those cases in which mathematicians abuse notation in the interest of concision.)
@@ -246,7 +242,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=1F</title>
     <statement>
       <p>
         Let <m>S</m>, <m>T</m>, and <m>U</m> be sets, and let <m>f: S\to T</m> and <m>g: T\to U</m> be onto. Prove that <m>g \circ f</m> is onto.

--- a/ptx/section2-2.ptx
+++ b/ptx/section2-2.ptx
@@ -2,7 +2,6 @@
 <section>
   <title>Exercises, Part I</title>
   <exercise>
-    <title>ID=2B</title>
     <statement>
       <p>
         For each of the following, write Y if the given <q>operation</q> is a well-defined binary operation on the given set; otherwise, write N. In each case in which it <em>isn't</em> a well-defined binary operation on the set, provide a <em>brief</em> explanations. You do not need to prove or explain anything in the cases in which it <em>is</em> a binary operation.
@@ -63,7 +62,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=2D</title>
     <statement>
       <p>
         Define <m>*</m> on <m>\fatq</m> by <m>p*q=pq+1</m>. Prove or disprove that <m>*</m> is (a) commutative; (b) associative.
@@ -87,7 +85,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=2E</title>
     <statement>
       <p>
         Prove that matrix multiplication is not commutative on <m>\M_2(\fatr)</m>.
@@ -115,7 +112,6 @@
     </p>
   </solution>
   <exercise>
-    <title>ID=2G</title>
     <statement>
       <p>
         Prove or disprove each of the following statements.
@@ -210,7 +206,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=2H</title>
     <statement>
       <p>
         Let <m>*</m> be an associative and commutative binary operation on a set <m>S</m>. An element <m>u\in S</m> is said to be an <em>idempotent</em> in <m>S</m> if <m>u*u=u</m>. Let <m>H</m> be the set of all idempotents in <m>S</m>. Prove that <m>H</m> is closed under <m>*</m>.

--- a/ptx/section2-6.ptx
+++ b/ptx/section2-6.ptx
@@ -50,10 +50,10 @@
     </statement>
   </definition>
 
-  <example>
+  <example xml:id="cong_ex">
     <statement>
       <p>
-        {cong.ex} <m>1, 7, 13,</m> and <m>-5</m> are all congruent mod <m>6</m>.
+        <m>1, 7, 13,</m> and <m>-5</m> are all congruent mod <m>6</m>.
       </p>
     </statement>
   </example>
@@ -347,10 +347,9 @@
     </statement>
   </example>
 
-  <example>
+  <example xml:id="gpprod">
     <statement>
       <p>
-        {gpprod}
         Let <m>\langle G_1,*_1\rangle</m>, <m>\langle G_2,*_2\rangle</m> , <m>\ldots</m>, <m>\langle G_n,*_n\rangle</m> be groups (<m>n\in \Z^+</m>). Then the <em>group product</em>
         <me>
           G=G_1\times G_2\times \cdots \times G_n

--- a/ptx/section2-8.ptx
+++ b/ptx/section2-8.ptx
@@ -2,7 +2,6 @@
 <section>
   <title>Exercises, Part II</title>
   <exercise>
-    <title>ID=2A</title>
     <statement>
       <p>
         True/False. For each of the following, write T if the statement is
@@ -112,7 +111,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=2F</title>
     <statement>
       <p>
         Let <m>G</m> be the set of all functions from <m>\Z</m> to <m>\fatr</m>. Prove that pointwise multiplication on <m>G</m> is commutative. (<em>Note.</em> To prove that two functions, <m>h</m> and <m>j</m>, sharing the same domain <m>D</m> are equal, you need to show that <m>h(x)=j(x)</m> for every <m>x\in D</m>.)
@@ -131,7 +129,6 @@
     </p>
   </solution>
   <exercise>
-    <title>ID=2J</title>
     <statement>
       <p>
         Decide which of the following binary structures are groups. For each, if the binary structure <em>isn't</em> a group, prove that. (Remember, you should <em>not</em> state that inverses do or do not exist for elements until you have made sure that the structure contains an identity element!) If the binary structure <em>is</em> a group, prove that.
@@ -211,7 +208,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=2K</title>
     <statement>
       <p>
         Give an example of an abelian group containing 711 elements.
@@ -225,7 +221,6 @@
     </p>
   </solution>
   <exercise>
-    <title>ID=2M</title>
     <statement>
       <p>
         Let <m>n\in \Z</m>. Prove that <m>n\Z</m> is a group under the usual addition of integers. <em>Note:</em> You may use the fact that <m>\langle n\Z,+\rangle</m> is a binary structure if you provide a reference for this fact.
@@ -272,7 +267,6 @@
     </p>
   </solution>
   <exercise>
-    <title>ID=2N</title>
     <statement>
       <p>
         Let <m>n\in \Z^+</m>. Prove that <m>SL(n,\fatr)</m> is a group under matrix multiplication.
@@ -317,7 +311,6 @@
     </p>
   </solution>
   <exercise>
-    <title>ID=2P</title>
     <statement>
       <ol>
       <li>
@@ -406,7 +399,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=2O</title>
     <statement>
       <p>
         Let <m>G</m> be a group with identity element <m>e</m>. Prove that if every element of <m>G</m> is its own inverse, then <m>G</m> is abelian.
@@ -431,7 +423,6 @@
     </p>
   </solution>
   <exercise>
-    <title>ID=2R, subtitle=(Extra Credit)</title>
     <statement>
       <p>
         Let <m>G</m> be a group. The subset

--- a/ptx/section3-2.ptx
+++ b/ptx/section3-2.ptx
@@ -37,10 +37,9 @@
     </p>
   </remark>
 
-  <example>
+  <example xml:id="homos">
     <statement>
       <p>
-        {homos}
         For each of the following, decide whether or not the given function
         <m>\phi</m> from one binary structure to another is a homomorphism, and,
         if so, if it is an isomorphism. Prove or disprove your answers! For

--- a/ptx/section3-3.ptx
+++ b/ptx/section3-3.ptx
@@ -310,10 +310,10 @@
     A <em>nonexample</em> of a group invariant is the property of being a subset of <m>\fatr</m>.
   </p>
 
-  <example>
+  <example xml:id="rgl">
     <statement>
       <p>
-        {rgl} The group <m>\fatr</m> cannot be isomorphic to the group <m>GL(2,\fatr)</m> since the former group is abelian and the latter nonabelian.
+        The group <m>\fatr</m> cannot be isomorphic to the group <m>GL(2,\fatr)</m> since the former group is abelian and the latter nonabelian.
       </p>
     </statement>
   </example>
@@ -330,10 +330,10 @@
     Sometimes we must resort to trickier methods in order to decide whether or not two groups are isomorphic.
   </p>
 
-  <example>
+  <example xml:id="zq">
     <statement>
       <p>
-        {zq} The groups <m>\Z</m> and <m>\fatq</m> are not isomorphic. We use contradiction to prove this. Suppose that <m>\Z</m> and <m>\fatq</m> are isomorphic via isomorphism
+        The groups <m>\Z</m> and <m>\fatq</m> are not isomorphic. We use contradiction to prove this. Suppose that <m>\Z</m> and <m>\fatq</m> are isomorphic via isomorphism
         <m>\phi :\fatq \to \Z</m>. Let <m>a\in \fatq</m>. Then <m>a/2 \in \fatq</m> with
         <m>a/2 + a/2 =a</m>. Then
         <me>
@@ -348,10 +348,9 @@
     </statement>
   </example>
 
-  <example>
+  <example xml:id="x4nonunique">
     <statement>
       <p>
-        {4nonunique}
         The groups <m>\Z_4</m> and <m>V=\Z_2^2</m> are not isomorphic. Why? Well, they are both abelian of order 4, so we cannot use cardinality or commutativity to prove they are nonisomorphic. The gist of our argument will be to note that every element in <m>V</m> is its own inverse; so if <m>V</m> and <m>\Z_4</m> are isomorphic (hence structurally identical) we must have that every element of <m>\Z_4</m> is also its own inverse, which doesn't hold (e.g., in <m>\Z_4</m>, <m>3+3=2</m>, not <m>0</m>).
       </p>
 

--- a/ptx/section3-4.ptx
+++ b/ptx/section3-4.ptx
@@ -2,7 +2,6 @@
 <section>
   <title>Exercises</title>
   <exercise>
-    <title>ID=3A</title>
     <statement>
       <p>
         True/False. For each of the following, write T if the statement is
@@ -233,7 +232,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=3B</title>
     <statement>
       <p>
         Complete the group tables for <m>\Z_4</m> and <m>\Z_8^{\times}</m>. Use the group tables to decide whether or not <m>\Z_4</m> and <m>\Z_8^{\times}</m> are isomorphic to one another. (You do not need to provide a proof.)
@@ -261,7 +259,6 @@
     </p>
   </solution>
   <exercise>
-    <title>ID=3C</title>
     <statement>
       <p>
         Let <m>n\in \Z^+</m>. Prove that <m>\langle n\Z,+\rangle  \simeq \langle \Z,+\rangle</m>.
@@ -285,7 +282,6 @@
     </p>
   </solution>
   <exercise>
-    <title>ID=3D</title>
     <statement>
       <ol>
         <li>
@@ -327,7 +323,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=3E,subtitle=(Extra Credit)</title>
     <statement>
       <p>
         Let <m>\langle G,\cdot\rangle</m> and <m>\langle G',\cdot'\rangle</m> be groups with identity elements <m>e</m> and <m>e'</m>, respectively, and let <m>\phi</m> be a homomorphism from <m>G</m> to <m>G'</m>. Let <m>a\in G</m>. Prove that <m>\phi(a)^{-1}=\phi(a^{-1})</m>.

--- a/ptx/section4-1.ptx
+++ b/ptx/section4-1.ptx
@@ -27,73 +27,70 @@
     </p>
   </warning>
 
-  <example>
+  <example xml:id="subsetvsubgp1">
     <statement>
-      <p>
-        {subsetvsubgp1}
-        <ol>
-          <li>
-            <p>
-              Consider the subset <m>\Z</m> of the group <m>\fatq</m>, assuming that <m>\fatq</m> is equipped with the usual addition of real numbers (as we indicated above that we would assume, by default).  Since we already know that <m>\Z</m> is a group under this operation, <m>\Z</m> is not just a subset but in fact a subgroup of <m>\fatq</m> (under addition).
-            </p>
-          </li>
+      <ol>
+        <li>
+          <p>
+            Consider the subset <m>\Z</m> of the group <m>\fatq</m>, assuming that <m>\fatq</m> is equipped with the usual addition of real numbers (as we indicated above that we would assume, by default).  Since we already know that <m>\Z</m> is a group under this operation, <m>\Z</m> is not just a subset but in fact a subgroup of <m>\fatq</m> (under addition).
+          </p>
+        </li>
 
-          <li>
-            <p>
-              Instead, consider the subset <m>\fatq^+</m> of the group <m>\fatq</m>.  This
-              subset is <em>not</em> a group under <m>\fatq</m>'s operation <m>+</m>,
-              since it does not contain an identity element for <m>+</m>.  Therefore,
-              <m>\fatq^+</m> is a subset but not a subgroup of <m>\fatq</m>.
-            </p>
-          </li>
+        <li>
+          <p>
+            Instead, consider the subset <m>\fatq^+</m> of the group <m>\fatq</m>.  This
+            subset is <em>not</em> a group under <m>\fatq</m>'s operation <m>+</m>,
+            since it does not contain an identity element for <m>+</m>.  Therefore,
+            <m>\fatq^+</m> is a subset but not a subgroup of <m>\fatq</m>.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              Let <m>I</m> be the subset
-              <me>
-                I=\fatr-\fatq=\{x\in \fatr: x
-                \mbox{ is irrational} \}
-              </me>
-              of the group <m>\fatr</m>. The set
-              <m>I</m> is <em>not</em> a group under <m>\fatr</m>'s
-              operation <m>+</m> since it is not closed under addition:
-              for instance, <m>\pi, -\pi \in I</m>, but
-              <m>\pi+(-\pi)=0\not\in I</m>.  So <m>I</m> is a subset but not a
-              subgroup of <m>\fatr</m>.
-            </p>
-          </li>
+        <li>
+          <p>
+            Let <m>I</m> be the subset
+            <me>
+              I=\fatr-\fatq=\{x\in \fatr: x
+              \mbox{ is irrational} \}
+            </me>
+            of the group <m>\fatr</m>. The set
+            <m>I</m> is <em>not</em> a group under <m>\fatr</m>'s
+            operation <m>+</m> since it is not closed under addition:
+            for instance, <m>\pi, -\pi \in I</m>, but
+            <m>\pi+(-\pi)=0\not\in I</m>.  So <m>I</m> is a subset but not a
+            subgroup of <m>\fatr</m>.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              Consider the subset <m>\Z^+</m> of the group <m>\fatr^+</m>.
-              The set <m>\Z^+</m> is closed under multiplication, multiplication is
-              associative on <m>\Z^+</m>, and <m>\Z^+</m> does contain an identity element
-              (namely, 1).  However, most elements of <m>\Z^+</m> do not have inverses
-              in <m>\Z^+</m> under multiplication: for instance, the inverse of <m>3</m>
-              would have to be <m>1/3</m>, but <m>1/3\not\in \Z^+</m>.  Therefore, <m>\Z^+</m> is
-              a subset but not a subgroup of <m>\fatr^+</m>.
-            </p>
-          </li>
+        <li>
+          <p>
+            Consider the subset <m>\Z^+</m> of the group <m>\fatr^+</m>.
+            The set <m>\Z^+</m> is closed under multiplication, multiplication is
+            associative on <m>\Z^+</m>, and <m>\Z^+</m> does contain an identity element
+            (namely, 1).  However, most elements of <m>\Z^+</m> do not have inverses
+            in <m>\Z^+</m> under multiplication: for instance, the inverse of <m>3</m>
+            would have to be <m>1/3</m>, but <m>1/3\not\in \Z^+</m>.  Therefore, <m>\Z^+</m> is
+            a subset but not a subgroup of <m>\fatr^+</m>.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              Consider the subset <m>GL(n,\fatr)</m> of <m>\M_n(\fatr)</m>.  We know that <m>GL(n,\fatr)</m> is a group, so it might be tempting to say that it is a subgroup of <m>\M_n(\fatr)</m>; to be a subgroup of <m>\M_n(\fatr)</m>, <m>GL(n,\fatr)</m> must be a group under <m>\M_n(\fatr)</m>'s operation, which is matrix addition.  While <m>GL(n,\fatr)</m> is a group under matrix multiplication, it is not a group under matrix addition: for instance, it is not closed under matrix addition, since <m>I_n, -I_n\in GL(n,\fatr)</m> but <m>I_n+(-I_n)</m> is the matrix consisting of all zeros, which is not in <m>GL(n,\fatr)</m>. So <m>GL(n,\fatr)</m> is a subset but not a subgroup of <m>\M_n(\fatr)</m>.
-            </p>
-          </li>
+        <li>
+          <p>
+            Consider the subset <m>GL(n,\fatr)</m> of <m>\M_n(\fatr)</m>.  We know that <m>GL(n,\fatr)</m> is a group, so it might be tempting to say that it is a subgroup of <m>\M_n(\fatr)</m>; to be a subgroup of <m>\M_n(\fatr)</m>, <m>GL(n,\fatr)</m> must be a group under <m>\M_n(\fatr)</m>'s operation, which is matrix addition.  While <m>GL(n,\fatr)</m> is a group under matrix multiplication, it is not a group under matrix addition: for instance, it is not closed under matrix addition, since <m>I_n, -I_n\in GL(n,\fatr)</m> but <m>I_n+(-I_n)</m> is the matrix consisting of all zeros, which is not in <m>GL(n,\fatr)</m>. So <m>GL(n,\fatr)</m> is a subset but not a subgroup of <m>\M_n(\fatr)</m>.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              Consider the subset <m>H=\{0,2\}</m> of <m>\Z_4</m>.  The subset <m>H</m> is closed under addition modulo 4 (<m>0+0=0</m>, <m>0+2=2+0=2</m>, <m>2+2=0</m>), addition modulo 4 is always associative, <m>H</m> contains an identity element (namely, 0) under addition modulo 4, and both 0 and 2 have inverses in <m>\Z_4</m> under this operation (0 and 2 are each their own inverses).  Thus, <m>H</m> <em>is</em> a subgroup of <m>\Z_4</m>.
-            </p>
-          </li>
+        <li>
+          <p>
+            Consider the subset <m>H=\{0,2\}</m> of <m>\Z_4</m>.  The subset <m>H</m> is closed under addition modulo 4 (<m>0+0=0</m>, <m>0+2=2+0=2</m>, <m>2+2=0</m>), addition modulo 4 is always associative, <m>H</m> contains an identity element (namely, 0) under addition modulo 4, and both 0 and 2 have inverses in <m>\Z_4</m> under this operation (0 and 2 are each their own inverses).  Thus, <m>H</m> <em>is</em> a subgroup of <m>\Z_4</m>.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              Let <m>G</m> be a group.  Then <m>\{e_G\}</m> and <m>G</m> are clearly both subgroups of <m>G</m>.
-            </p>
-          </li>
-        </ol>
-      </p>
+        <li>
+          <p>
+            Let <m>G</m> be a group.  Then <m>\{e_G\}</m> and <m>G</m> are clearly both subgroups of <m>G</m>.
+          </p>
+        </li>
+      </ol>
     </statement>
   </example>
 

--- a/ptx/section4-2.ptx
+++ b/ptx/section4-2.ptx
@@ -33,10 +33,10 @@
     </statement>
   </theorem>
 
-  <example>
+  <example xml:id="subsetvsubgp2">
     <statement>
       <p>
-        {subsetvsubgp2} For each of the following, prove that the given subset <m>H</m> of group <m>G</m> is or is not a subgroup of <m>G</m>.
+        For each of the following, prove that the given subset <m>H</m> of group <m>G</m> is or is not a subgroup of <m>G</m>.
         <ol>
           <li>
             <p>
@@ -74,10 +74,10 @@
     </statement>
   </example>
 
-  <example>
+  <example xml:id="FHKL">
     <statement>
       <p>
-        {FHKL} Consider the group <m>\langle F,+\rangle</m>, where <m>F</m> is the set of all functions from <m>\fatr</m> to <m>\fatr</m> and <m>+</m> is pointwise addition. Which of the following are subgroups of <m>F</m>?
+        Consider the group <m>\langle F,+\rangle</m>, where <m>F</m> is the set of all functions from <m>\fatr</m> to <m>\fatr</m> and <m>+</m> is pointwise addition. Which of the following are subgroups of <m>F</m>?
         <ol>
           <li class="custom-list-style-type" label="" >
 

--- a/ptx/section4-3.ptx
+++ b/ptx/section4-3.ptx
@@ -2,7 +2,6 @@
 <section>
   <title>Exercises</title>
   <exercise>
-    <title>ID=4A</title>
     <statement>
       <p>
         True/False. For each of the following, write T if the statement is
@@ -64,7 +63,6 @@
     </ol>
   </solution>
   <exercise>
-    <title>ID=4B</title>
     <statement>
       <p>
         Give specific, precise examples of the following groups <m>G</m> with subgroups <m>H</m>:
@@ -282,7 +280,6 @@
     </p>
   </solution>
   <exercise>
-    <title>ID=4D, subtitle=(Extra Credit)</title>
     <statement>
       <p>
         Recall that an element <m>u</m> of a binary structure is said to be an <em>idempotent</em> if <m>u^2=u</m>. Let <m>G</m> be an abelian group, and let <m>U</m> be the set of all idempotents of <m>G</m>. Prove that <m>U</m> is a subgroup of <m>G</m>.

--- a/ptx/section5-1.ptx
+++ b/ptx/section5-1.ptx
@@ -204,119 +204,116 @@
     Here are some examples of cyclic subgroups of groups, and orders of group elements.
   </p>
 
-  <example>
+  <example xml:id="csexs">
     <statement>
-      <p>
-        {csexs}
-        <ol>
-          <li>
-            <p>
-              In <m>\Z</m>, <m>\langle 2\rangle =\{\ldots,-4,-2,0,2,4,\ldots\}=2\Z</m>. More generally, given any <m>n\in \Z</m>, in <m>\Z</m> we have <m>\langle n\rangle =n\Z</m>. For <m>a\in \Z</m>, <m>o(a)=\infty</m> if <m>a\neq 0</m>; <m>o(0)=1</m>.
-            </p>
-          </li>
+      <ol>
+        <li>
+          <p>
+            In <m>\Z</m>, <m>\langle 2\rangle =\{\ldots,-4,-2,0,2,4,\ldots\}=2\Z</m>. More generally, given any <m>n\in \Z</m>, in <m>\Z</m> we have <m>\langle n\rangle =n\Z</m>. For <m>a\in \Z</m>, <m>o(a)=\infty</m> if <m>a\neq 0</m>; <m>o(0)=1</m>.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              In <m>\Z_8</m>, we have <m>\langle 0\rangle =\{0\}</m>, <m>\langle 1\rangle =\langle 3\rangle =\langle 5\rangle =\langle 7\rangle =\Z_8,</m> <m>\langle 2\rangle =\langle 6\rangle =\{0,2,4,6\},</m> and <m>\langle 4\rangle =\{0,4\}</m>.
-            </p>
-          </li>
+        <li>
+          <p>
+            In <m>\Z_8</m>, we have <m>\langle 0\rangle =\{0\}</m>, <m>\langle 1\rangle =\langle 3\rangle =\langle 5\rangle =\langle 7\rangle =\Z_8,</m> <m>\langle 2\rangle =\langle 6\rangle =\{0,2,4,6\},</m> and <m>\langle 4\rangle =\{0,4\}</m>.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              In <m>\fatr</m>, <m>\langle \pi\rangle =\pi\Z</m>, so <m>o(\pi)=\infty</m>.
-            </p>
-          </li>
+        <li>
+          <p>
+            In <m>\fatr</m>, <m>\langle \pi\rangle =\pi\Z</m>, so <m>o(\pi)=\infty</m>.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              In <m>\fatr^*</m>, <m>\langle \pi\rangle =\{\pi^n:n\in \Z\}</m>. Again, <m>o(\pi)=\infty</m>.
-            </p>
-          </li>
+        <li>
+          <p>
+            In <m>\fatr^*</m>, <m>\langle \pi\rangle =\{\pi^n:n\in \Z\}</m>. Again, <m>o(\pi)=\infty</m>.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              In <m>\M_2(\fatr)</m>,
-              <me>
-                \left\langle \left[
-                \begin{array}{cc}
-                1 \amp  1 \\
-                0 \amp  1
-                \end{array} 
-                \right]\right\rangle =\left\{\left[
-                \begin{array}{cc}
-                c \amp  c \\
-                0 \amp  c
-                \end{array} 
-                \right] : c\in \Z \right\}= \left\{c\left[
-                \begin{array}{cc}
-                1 \amp  1 \\
-                0 \amp  1
-                \end{array} 
-                \right] : c\in \Z \right\}.
-              </me>
-              The order of the the matrix is therefore infinity.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              In <m>\M_2(\Z_2)</m>, if <m>A=\left[
+        <li>
+          <p>
+            In <m>\M_2(\fatr)</m>,
+            <me>
+              \left\langle \left[
               \begin{array}{cc}
               1 \amp  1 \\
               0 \amp  1
               \end{array} 
-              \right]</m>, then <m>\langle A\rangle =\{A, \0\}</m>, so <m>A</m> has order 2.
-            </p>
-          </li>
-
-          <li>
-            <p>
-              In <m>GL(2,\Z_2)</m>, <m>\left[
+              \right]\right\rangle =\left\{\left[
+              \begin{array}{cc}
+              c \amp  c \\
+              0 \amp  c
+              \end{array} 
+              \right] : c\in \Z \right\}= \left\{c\left[
               \begin{array}{cc}
               1 \amp  1 \\
               0 \amp  1
               \end{array} 
-              \right]</m> has order 2. (Why?)
-            </p>
-          </li>
+              \right] : c\in \Z \right\}.
+            </me>
+            The order of the the matrix is therefore infinity.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              In <m>GL(2,\fatr)</m>, <m>\left[
-              \begin{array}{cr}
-              0 \amp  -1 \\
-              1 \amp  0
-              \end{array} 
-              \right]</m> has order 4. (Why?)
-            </p>
-          </li>
+        <li>
+          <p>
+            In <m>\M_2(\Z_2)</m>, if <m>A=\left[
+            \begin{array}{cc}
+            1 \amp  1 \\
+            0 \amp  1
+            \end{array} 
+            \right]</m>, then <m>\langle A\rangle =\{A, \0\}</m>, so <m>A</m> has order 2.
+          </p>
+        </li>
 
-          <li>
-            <p>
-              In <m>GL(2,\fatr)</m>, <m>\left[
-              \begin{array}{cc}
-              1 \amp  1 \\
-              0 \amp  1
-              \end{array} 
-              \right]</m> has infinite order. (Why?)
-            </p>
-          </li>
+        <li>
+          <p>
+            In <m>GL(2,\Z_2)</m>, <m>\left[
+            \begin{array}{cc}
+            1 \amp  1 \\
+            0 \amp  1
+            \end{array} 
+            \right]</m> has order 2. (Why?)
+          </p>
+        </li>
 
-          <li>
-            <p>
-              In <m>GL(4,\Z_2)</m>,
-              <m>A=\left[
-              \begin{array}{cccc}
-              0 \amp  0 \amp  1 \amp  0 \\
-              0 \amp  0 \amp  0 \amp  1 \\
-              1 \amp  0 \amp  0 \amp  0 \\
-              0 \amp  1 \amp  0 \amp  0
-              \end{array} 
-              \right]</m> has order 2. (Why?)
-            </p>
-          </li>
-        </ol>
-      </p>
+        <li>
+          <p>
+            In <m>GL(2,\fatr)</m>, <m>\left[
+            \begin{array}{cr}
+            0 \amp  -1 \\
+            1 \amp  0
+            \end{array} 
+            \right]</m> has order 4. (Why?)
+          </p>
+        </li>
+
+        <li>
+          <p>
+            In <m>GL(2,\fatr)</m>, <m>\left[
+            \begin{array}{cc}
+            1 \amp  1 \\
+            0 \amp  1
+            \end{array} 
+            \right]</m> has infinite order. (Why?)
+          </p>
+        </li>
+
+        <li>
+          <p>
+            In <m>GL(4,\Z_2)</m>,
+            <m>A=\left[
+            \begin{array}{cccc}
+            0 \amp  0 \amp  1 \amp  0 \\
+            0 \amp  0 \amp  0 \amp  1 \\
+            1 \amp  0 \amp  0 \amp  0 \\
+            0 \amp  1 \amp  0 \amp  0
+            \end{array} 
+            \right]</m> has order 2. (Why?)
+          </p>
+        </li>
+      </ol>
     </statement>
   </example>
 

--- a/ptx/section6-1.ptx
+++ b/ptx/section6-1.ptx
@@ -11,10 +11,10 @@
     </statement>
   </definition>
 
-  <example>
+  <example xml:id="stperm">
     <statement>
       <p>
-        {stperm} Let <m>A</m> be the set <m>A=\{\Delta, \star, \dollar\}</m>. Then the functions <m>\sigma : A\to A</m> defined by
+        Let <m>A</m> be the set <m>A=\{\Delta, \star, \dollar\}</m>. Then the functions <m>\sigma : A\to A</m> defined by
         <me>
           \sigma(\Delta)=\star,
           \sigma(\star)=\Delta,  \mbox{and }  \sigma(\dollar)=\dollar

--- a/ptx/section6-2.ptx
+++ b/ptx/section6-2.ptx
@@ -23,10 +23,10 @@
     For instance, if <m>\sigma</m> sends <m>1</m> to <m>2</m>, we'd write the number <m>2</m> below the number <m>1</m>. The convention is to enclose these two rows of numbers in a single set of parentheses, as in the following example.
   </p>
 
-  <example>
+  <example xml:id="nocommute">
     <statement>
       <p>
-        {nocommute} We can denote the element <m>\sigma</m> of <m>S_3</m> that swaps <m>1</m> and <m>2</m> and fixes <m>3</m> by
+        We can denote the element <m>\sigma</m> of <m>S_3</m> that swaps <m>1</m> and <m>2</m> and fixes <m>3</m> by
         <me>
           \sigma = \left(\begin{array}{ccc}1\amp 2\amp 3\\ 2\amp 1\amp 3
           \end{array} \right),
@@ -79,10 +79,10 @@
     </statement>
   </definition>
 
-  <example>
+  <example xml:id="tr">
     <statement>
       <p>
-        {tr} The permutation <m>\tau</m> in <m>S_3</m> that sends <m>1</m> to <m>3</m>, <m>2</m> to <m>1</m>, and <m>3</m> to <m>2</m> is a cycle. It can be denoted by <m>\tau =(132)</m>.
+        The permutation <m>\tau</m> in <m>S_3</m> that sends <m>1</m> to <m>3</m>, <m>2</m> to <m>1</m>, and <m>3</m> to <m>2</m> is a cycle. It can be denoted by <m>\tau =(132)</m>.
         Similarly, the cycle <m>\rho</m> in <m>S_3</m> swapping <m>1</m> and <m>3</m> can be denoted by <m>\rho=(13)</m>. On the other hand, the permutation in <m>S_4</m> that swaps <m>1</m> with <m>2</m> and <m>3</m> with <m>4</m> is
         <em>not</em> a cycle.
       </p>
@@ -195,10 +195,10 @@
     </statement>
   </example>
 
-  <example>
+  <example xml:id="s9ex">
     <statement>
       <p>
-        {s9ex} In <m>S_9</m>, let <m>\sigma=(134)</m>, <m>\tau=(26)(17)</m>, and <m>\rho=(358)(12)</m>. Find the following, writing your answers using disjoint cycle notation.
+        In <m>S_9</m>, let <m>\sigma=(134)</m>, <m>\tau=(26)(17)</m>, and <m>\rho=(358)(12)</m>. Find the following, writing your answers using disjoint cycle notation.
       </p>
       <tabular>
         <row>

--- a/ptx/section6-3.ptx
+++ b/ptx/section6-3.ptx
@@ -59,7 +59,6 @@
   <example>
     <statement>
       <p>
-        \
         In <m>S_3</m>, the permutations <m>e</m>, <m>(123)=(13)(12)</m>, and <m>(132)=(12)(13)</m> are even, while the permutations <m>(12)</m>, <m>(13)</m>, and <m>(23)</m> are odd.
       </p>
     </statement>
@@ -68,7 +67,6 @@
   <example>
     <statement>
       <p>
-        \
         List all of the even [resp., odd] permutations in <m>S_4</m>.
       </p>
     </statement>

--- a/ptx/section7-2.ptx
+++ b/ptx/section7-2.ptx
@@ -155,10 +155,10 @@
     </p>
   </remark>
 
-  <example>
+  <example xml:id="s3_ex">
     <statement>
       <p>
-        {s3.ex} Find the left and right cosets of <m>H=\langle (12)\rangle</m> in
+        Find the left and right cosets of <m>H=\langle (12)\rangle</m> in
         <m>S_3</m>.
         <me>
           \begin{array}{l|l|l}
@@ -181,10 +181,10 @@
     </statement>
   </example>
 
-  <example>
+  <example xml:id="d4_ex">
     <statement>
       <p>
-        {d4.ex} Find the left and right cosets of <m>H=\langle f\rangle</m> in
+        Find the left and right cosets of <m>H=\langle f\rangle</m> in
         <m>D_4</m>.
       </p>
 
@@ -319,10 +319,10 @@
     </statement>
   </example>
 
-  <example>
+  <example xml:id="z6_ex">
     <statement>
       <p>
-        {z6.ex} Find the cosets of <m>H=\langle 4\rangle</m> in <m>\Z_{12}</m>.
+        Find the cosets of <m>H=\langle 4\rangle</m> in <m>\Z_{12}</m>.
       </p>
 
       <p>

--- a/ptx/section7-3.ptx
+++ b/ptx/section7-3.ptx
@@ -35,10 +35,10 @@
     </statement>
   </example>
 
-  <example>
+  <example xml:id="indices_ex">
     <statement>
       <p>
-        {indices.ex} Referring to our previous examples, we have:
+        Referring to our previous examples, we have:
         <me>
           \begin{array}{cl} \amp (S_3:\langle (12)\rangle )=3,\\
           \amp (D_4:\langle f\rangle )=4, \\

--- a/ptx/section8-2.ptx
+++ b/ptx/section8-2.ptx
@@ -231,10 +231,10 @@
     homomorphism from <m>G</m> to another group.
   </p>
 
-  <example>
+  <example xml:id="slnormgl">
     <statement>
       <p>
-        {slnormgl} Let <m>n\in \Z^+</m>. Here is a rather elegant proof of the fact that
+        Let <m>n\in \Z^+</m>. Here is a rather elegant proof of the fact that
         <m>SL(n,\fatr)</m> is a normal subgroup of <m>GL(n,\fatr)</m>: Define <m>\phi:
         GL(n,\fatr) \to \fatr^*</m> by <m>\phi(A)=\det A</m>. Clearly, <m>\phi</m> is a
         homomorphism, and since the identity element of <m>\fatr^*</m> is 1,


### PR DESCRIPTION
The visible tags on the examples have been converted to xml ids,
and the tags on the exercises have been eliminated.
Let me know if you needed something different.

Should fix issues #5 and #6 

Be sure to look at the changes in GitHub before accepting the pull request.